### PR TITLE
Fixed issue in Node 0.10.1

### DIFF
--- a/lib/uglify.js
+++ b/lib/uglify.js
@@ -191,10 +191,10 @@ module.exports = function( _, anvil ) {
                 // Is there a sourcemap in the config that matches the current file.
                 sourceMapExists = self.sourceMaps[ path.join( file.relativePath, file.name ) ],
                 // The actual destination of the sourceMap
-                sourceMapDestination = sourceMapExists === true ? fileForSourceMap + ".map" : path.join( output, sourceMapExists ),
+                sourceMapDestination = sourceMapExists === true ? fileForSourceMap + ".map" : path.join( output, String(sourceMapExists) ),
                 // The actual destination of the sourceMap
                 sourceMapActualDestination = sourceMapExists === true ? path.join( anvil.config.working, file.relativePath, file.name ) + ".map"
-                    : path.join( anvil.config.working, sourceMapExists  ),
+                    : path.join( anvil.config.working, String(sourceMapExists)  ),
                 // Options to pass to uglify.
                 uglifyOpts = _.extend({}, this.uglifyOptions, sourceMapExists ? {
                         outSourceMap: sourceMapDestination

--- a/src/uglify.js
+++ b/src/uglify.js
@@ -182,10 +182,10 @@ module.exports = function( _, anvil ) {
                 // Is there a sourcemap in the config that matches the current file.
                 sourceMapExists = self.sourceMaps[ path.join( file.relativePath, file.name ) ],
                 // The actual destination of the sourceMap
-                sourceMapDestination = sourceMapExists === true ? fileForSourceMap + ".map" : path.join( output, sourceMapExists ),
+                sourceMapDestination = sourceMapExists === true ? fileForSourceMap + ".map" : path.join( output, String(sourceMapExists) ),
                 // The actual destination of the sourceMap
                 sourceMapActualDestination = sourceMapExists === true ? path.join( anvil.config.working, file.relativePath, file.name ) + ".map"
-                    : path.join( anvil.config.working, sourceMapExists  ),
+                    : path.join( anvil.config.working, String(sourceMapExists)  ),
                 // Options to pass to uglify.
                 uglifyOpts = _.extend({}, this.uglifyOptions, sourceMapExists ? {
                         outSourceMap: sourceMapDestination


### PR DESCRIPTION
In the current version of Node, I was getting an error that said:

```
error running activity post-process : TypeError: Arguments to path.join must be strings
TypeError: Arguments to path.join must be strings
```

This will fix the issue I was seeing by wrapping the sourceMapExists as a string. If there is a better way, that works too, but this worked for me.
